### PR TITLE
Fix typo fin truncate_time and make at argument optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Kopiera ./sensitive.xml till /home/sebelino/.config/sl-cli/sensitive.xml? (y/n) 
 > y
 Skapar kataloger...
 Kopierar ./sensitive.xml -> /home/sebelino/.config/sl-cli/sensitive.xml
-usage: sl-cli [-h] [--verbose] from to at
-sl-cli.py: error: the following arguments are required: from, to, at
+usage: sl-cli [-h] [--verbose] from to [at]
+sl-cli.py: error: the following arguments are required: from, to
 ```
 
 ## Dependencies
@@ -57,7 +57,7 @@ $ source venv/bin/activate
 Med executablen **sl-cli** får du reseinformation direkt i terminalen. Se manualen:
 ```bash
 $ sl-cli -h
-usage: sl-cli [-h] [--verbose] from to at
+usage: sl-cli [-h] [--verbose] from to [at]
 
 positional arguments:
   from           Varifrån ska du resa?

--- a/slcli/sl_cli.py
+++ b/slcli/sl_cli.py
@@ -9,6 +9,7 @@ from pprint import pformat
 from time import time
 from shutil import copyfile
 from urllib.parse import unquote
+from datetime import datetime
 
 from slcli.apis.reseplanerare3 import tripapi, journeydetailapi as japi
 from slcli.apis.platsuppslag import api as papi
@@ -139,11 +140,15 @@ def main(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('origin', metavar='from', help="Varifrån ska du resa?")
     parser.add_argument('to', help="Vart ska du?")
-    parser.add_argument('at', help="När ska du bege dig?")
+    parser.add_argument('at', help="När ska du bege dig?", nargs='?',
+                        default=datetime.now().strftime('%H:%M'))
     parser.add_argument('--verbose', '-v', action='store_true',
                         help="Skriv ut debuggutskrifter")
     check_keys_installed()
     args = args if args else parser.parse_args()
+    if type(args.at) is str:
+        # Convert H:MM to HH:MM
+        args.at = datetime.strptime(args.at, "%H:%M").strftime("%H:%M")
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
         starttime = time()

--- a/slcli/sl_cli.py
+++ b/slcli/sl_cli.py
@@ -87,7 +87,7 @@ def travel(origin, destination, time):
     return result
 
 
-def truncate_time(time_string: str):
+def truncate_time(time_string):
     """ HH:MM:SS -> HH:MM """
     return ':'.join(time_string.split(':')[:2])
 


### PR DESCRIPTION
Om "at" inte ges så används nuvarande tid. 
Konvertera också "at" från H:MM till HH:MM, annars får användaren ett error om t ex 8:00 ges till funktionen.